### PR TITLE
make prototype_delete_function

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -31,6 +31,13 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def destroy
+    if @prototype.user_id == current_user.id
+      @prototype.destroy
+      redirect_to root_path, notice: 'Deleted successfully'
+    end
+  end
+
   private
 
   def prototype_params

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -2,7 +2,7 @@ class Prototype < ActiveRecord::Base
   validates :title, :catchcopy, :concept, presence: true
   belongs_to :user
   has_one :main_image, -> { where(role: 0) }, class_name: "PrototypeImage"
-  has_many :prototype_images
+  has_many :prototype_images, dependent: :delete_all
   accepts_nested_attributes_for :prototype_images, reject_if: :reject_sub_images, limit: 4
 
   def reject_sub_images(attributed)

--- a/app/views/prototypes/_prototype.html.haml
+++ b/app/views/prototypes/_prototype.html.haml
@@ -5,7 +5,7 @@
         %button.btn.btn-default{ id: "dropdownMenu", type: "button", data: { toggle: "dropdown" } } action
         %ul.dropdown-menu{ area: { labelledby: "dropdownMenu1" } }
           %li
-            = link_to "Delete", prototypes_path(prototype), method: :delete, data: { confirm: "Are you sure you want to permanently delete ?" }
+            = link_to "Delete", prototype_path(prototype), method: :delete, data: { confirm: "Are you sure you want to permanently delete ?" }
           %li
             = link_to "Edit",  edit_prototype_path(prototype)
     = link_to image_tag(prototype.prototype_images.main.first.image), prototype_path(prototype)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,3 +6,4 @@ Rails.application.routes.draw do
   resources :users, only: [:show, :edit, :update]
   resources :prototypes
 end
+


### PR DESCRIPTION
# WHAT

プロトタイプ削除機能の追加
# WHY

ユーザーがプロトタイプを削除できるようにするため
